### PR TITLE
Bypass safe YAML load

### DIFF
--- a/lib/mux_tf/yaml_cache.rb
+++ b/lib/mux_tf/yaml_cache.rb
@@ -1,6 +1,32 @@
 require "yaml/store"
 
 module YAML
+  # Explaination from @h4xnoodle:
+  #
+  # Since ruby 3+ and psych 4+, the yaml loading became extra safe so the
+  # expired_at timestamp in the yaml cache is no longer parsing for whatever reason.
+  #
+  # Attempts were made with
+  #
+  # `@store = YAML::Store.new path`
+  # =>
+  # `@store = YAML::Store.new(path, { aliases: true, permitted_classes: [Time] })`
+  # to get it to work but that didn't help, so decided to just bypass the safe
+  # loading, since the file is controlled by us for the version checking.
+  #
+  # This is to override the way that psych seems to be loading YAML.
+  # Instead of using 'load' which needs work to permit the 'Time' class
+  # (which from above I tried that and it wasn't working so I decided to just
+  # bypass and use what it was doing before).
+  # This brings us back to the equivalent that was working before in that unsafe
+  # load was used before the psych upgrade.
+  #
+  # This change: https://my.diffend.io/gems/psych/3.3.2/4.0.0 
+  # is the changes that 'cause the problem' and so I'm 'fixing it' by using the old equivalent.
+  # 
+  # Maybe the yaml cache needs more work to have 
+  # `YAML::Store.new(path, { aliases: true, permitted_classes: [Time] }) work.`
+  #
   class << self
     alias_method :load, :unsafe_load
   end

--- a/lib/mux_tf/yaml_cache.rb
+++ b/lib/mux_tf/yaml_cache.rb
@@ -1,5 +1,11 @@
 require "yaml/store"
 
+module YAML
+  class << self
+    alias_method :load, :unsafe_load
+  end
+end
+
 module MuxTf
   class YamlCache
     def initialize(path, default_ttl:)


### PR DESCRIPTION
Since ruby 3+ and psych 4+, the yaml loading became extra safe so the `expired_at` timestamp in the yaml cache is no longer parsing for whatever reason.

Attempts were made with 

`@store = YAML::Store.new path` => `@store = YAML::Store.new(path, { aliases: true, permitted_classes: [Time] })` to get it to work but that didn't help, so decided to just bypass the safe loading, since the file is controlled by us for the version checking.

ref: https://my.diffend.io/gems/psych/3.3.2/4.0.0

Error through the fetch in yaml store
![Screenshot 2023-04-23 at 11 48 14](https://user-images.githubusercontent.com/105841/233858982-c83657a1-079b-41a1-8ac5-2e5b313c72a2.png)
